### PR TITLE
DE6485 Add FK to groups

### DIFF
--- a/CI/SQL/20190225_141831_US16477-modify-projects-table.sql
+++ b/CI/SQL/20190225_141831_US16477-modify-projects-table.sql
@@ -117,6 +117,13 @@ GO
 ALTER TABLE [dbo].[cr_Projects] CHECK CONSTRAINT [FK_Projects_Project_Types]
 GO
 
+ALTER TABLE [dbo].[cr_Projects]  WITH CHECK ADD  CONSTRAINT [FK_Projects_Groups] FOREIGN KEY([Group_ID])
+REFERENCES [dbo].[Groups] ([Group_ID])
+GO
+
+ALTER TABLE [dbo].[cr_Projects] CHECK CONSTRAINT [FK_Projects_Project_Types]
+GO
+
 SET IDENTITY_INSERT cr_Projects ON
 INSERT INTO cr_Projects ([Project_ID],
 	[Project_Name],


### PR DESCRIPTION
## Purpose
Allow people to pick the project group from those in MP

## Approach
Adds a foreign key to the Group_ID field
