### PR TITLE
Feature/us16625 signup with kids under13

### DIFF
--- a/CI/SQL/20190313_135048_US16625-go-local-kids-security-for-go-local-api.sql
+++ b/CI/SQL/20190313_135048_US16625-go-local-kids-security-for-go-local-api.sql
@@ -1,16 +1,48 @@
 USE MinistryPlatform
 GO
 
+DECLARE @GoLocalKidsPageId int = 649 --Assigned by Identity Maintenance DB
+IF NOT EXISTS (SELECT 1 FROM dp_Pages WHERE Page_ID = @GoLocalKidsPageId)
+BEGIN
+	SET IDENTITY_INSERT [dbo].[dp_Pages] ON
+	INSERT INTO [dbo].[dp_Pages]
+           ([Page_ID]
+		   ,[Display_Name]
+           ,[Singular_Name]
+           ,[Description]
+           ,[View_Order]
+           ,[Table_Name]
+           ,[Primary_Key]
+           ,[Display_Search]
+           ,[Default_Field_List]
+           ,[Selected_Record_Expression]
+           ,[Display_Copy]
+           ,[Suppress_New_Button])
+     VALUES
+           (@GoLocalKidsPageId
+		   ,'GO Local Kids'
+           ,'GO Local Kids'
+           ,'How many kids of each age range a person is bringing along to GO Local'
+           ,99
+           ,'cr_Go_Local_Kids'
+           ,'Go_Local_Kids_ID'
+           ,1
+           ,'Group_Participant_ID, Two_to_Seven_Count, Eight_to_Twelve_Count'
+           ,'Go_Local_Kids_ID'
+           ,1
+           ,0)
+	SET IDENTITY_INSERT [dbo].[dp_Pages] OFF
+END
+
 DECLARE @GoLocalRoleId int = 211
-DECLARE @GoLocalKidsSubPageId int = 620
-IF NOT EXISTS (SELECT 1 FROM dp_Role_Sub_Pages WHERE Role_ID = @GoLocalRoleId AND Sub_Page_ID = @GoLocalKidsSubPageId)
+IF NOT EXISTS (SELECT 1 FROM dp_Role_Pages WHERE Role_ID = @GoLocalRoleId AND Page_ID = @GoLocalKidsPageId)
 BEGIN 
-	INSERT INTO [dbo].[dp_Role_Sub_Pages]
+	INSERT INTO [dbo].[dp_Role_Pages]
            ([Role_ID]
-           ,[Sub_Page_ID]
+           ,[Page_ID]
            ,[Access_Level])
      VALUES
            (@GoLocalRoleId
-           ,@GoLocalKidsSubPageId
+           ,@GoLocalKidsPageId
            ,1)
 END

--- a/CI/SQL/20190313_135048_US16625-go-local-kids-security-for-go-local-api.sql
+++ b/CI/SQL/20190313_135048_US16625-go-local-kids-security-for-go-local-api.sql
@@ -1,0 +1,16 @@
+USE MinistryPlatform
+GO
+
+DECLARE @GoLocalRoleId int = 211
+DECLARE @GoLocalKidsSubPageId int = 620
+IF NOT EXISTS (SELECT 1 FROM dp_Role_Sub_Pages WHERE Role_ID = @GoLocalRoleId AND Sub_Page_ID = @GoLocalKidsSubPageId)
+BEGIN 
+	INSERT INTO [dbo].[dp_Role_Sub_Pages]
+           ([Role_ID]
+           ,[Sub_Page_ID]
+           ,[Access_Level])
+     VALUES
+           (@GoLocalRoleId
+           ,@GoLocalKidsSubPageId
+           ,1)
+END

--- a/CrdsGoLocalApi.Tests/Helpers/SignupDataHelpers.cs
+++ b/CrdsGoLocalApi.Tests/Helpers/SignupDataHelpers.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using CrdsGoLocalApi.Models;
+
+namespace CrdsGoLocalApi.Tests.Helpers
+{
+  public class SignupDataHelpers
+  {
+    public static VolunteerDTO MockSignupDataWithKids()
+    {
+      return new VolunteerDTO
+      {
+        FirstName = "Fred",
+        LastName = "Flintstone",
+        Email = "fred.flintstone@crossroads.net",
+        PhoneNumber = "123-456-7890",
+        BirthDate = new DateTime(1901, 01, 01),
+        KidsTwoToSevenCount = 1,
+        KidsEightToTwelveCount = 2,
+        ProjectId = 9876
+      };
+    }
+
+    public static VolunteerDTO MockSignupDataNoKids()
+    {
+      return new VolunteerDTO
+      {
+        FirstName = "Fred",
+        LastName = "Flintstone",
+        Email = "fred.flintstone@crossroads.net",
+        PhoneNumber = "123-456-7890",
+        BirthDate = new DateTime(1901, 01, 01),
+        ProjectId = 9876
+      };
+    }
+
+    public static MpProject MockProject()
+    {
+      return new MpProject
+      {
+        ProjectId = 9876,
+        GroupId = 54321
+      };
+    }
+  }
+}

--- a/CrdsGoLocalApi.Tests/Services/SignupServiceTests.cs
+++ b/CrdsGoLocalApi.Tests/Services/SignupServiceTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using CrdsGoLocalApi.Models;
+using CrdsGoLocalApi.Repositories.ContactData;
+using CrdsGoLocalApi.Repositories.HouseholdData;
+using CrdsGoLocalApi.Repositories.ParticipantData;
+using CrdsGoLocalApi.Repositories.ProjectData;
+using CrdsGoLocalApi.Services.Signup;
+using CrdsGoLocalApi.Tests.Helpers;
+using Moq;
+using Xunit;
+
+namespace CrdsGoLocalApi.Tests.Services
+{
+  public class SignupServiceTests : IDisposable
+  {
+    private readonly Mock<IContactDataRepository> _contactDataRepository;
+    private readonly Mock<IHouseholdDataRepository> _householdDataRepository;
+    private readonly Mock<IParticipantDataRepository> _participantDataRepository;
+    private readonly Mock<IProjectDataRepository> _projectDataRepository;
+
+    private readonly SignupService _fixture;
+
+    public SignupServiceTests()
+    {
+      _contactDataRepository = new Mock<IContactDataRepository>();
+      _householdDataRepository = new Mock<IHouseholdDataRepository>();
+      _participantDataRepository = new Mock<IParticipantDataRepository>();
+      _projectDataRepository = new Mock<IProjectDataRepository>();
+      _fixture = new SignupService(_contactDataRepository.Object, _householdDataRepository.Object, _participantDataRepository.Object, _projectDataRepository.Object);
+    }
+
+    public void Dispose()
+    {
+      _contactDataRepository.VerifyAll();
+      _householdDataRepository.VerifyAll();
+      _participantDataRepository.VerifyAll();
+      _projectDataRepository.VerifyAll();
+    }
+
+    [Fact]
+    public void ShouldCreateGoLocalKidsRecord()
+    {
+      var signupData = SignupDataHelpers.MockSignupDataWithKids();
+
+      _projectDataRepository.Setup(m => m.GetProject(signupData.ProjectId)).Returns(SignupDataHelpers.MockProject());
+      _contactDataRepository.Setup(m => m.CreateContact(It.IsAny<Contact>())).Returns(1234);
+      _householdDataRepository.Setup(m => m.CreateHousehold(It.IsAny<Household>())).Returns(5678);
+      _participantDataRepository.Setup(m => m.CreateParticipant(It.IsAny<Participant>())).Returns(9012);
+      _participantDataRepository.Setup(m => m.CreateGroupParticipant(It.IsAny<GroupParticipant>())).Returns(3456);
+      _participantDataRepository.Setup(m => m.CreateEventParticipant(It.IsAny<EventParticipant>())).Returns(7890);
+      _participantDataRepository.Setup(m => m.CreateGoLocalKids(It.IsAny<GoLocalKids>())).Returns(1357);
+
+      var result = _fixture.SignupUser(signupData);
+
+      Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldNotCreateGoLocalKidsRecord()
+    {
+      var signupData = SignupDataHelpers.MockSignupDataNoKids();
+
+      _projectDataRepository.Setup(m => m.GetProject(signupData.ProjectId)).Returns(SignupDataHelpers.MockProject());
+      _contactDataRepository.Setup(m => m.CreateContact(It.IsAny<Contact>())).Returns(1234);
+      _householdDataRepository.Setup(m => m.CreateHousehold(It.IsAny<Household>())).Returns(5678);
+      _participantDataRepository.Setup(m => m.CreateParticipant(It.IsAny<Participant>())).Returns(9012);
+      _participantDataRepository.Setup(m => m.CreateGroupParticipant(It.IsAny<GroupParticipant>())).Returns(3456);
+      _participantDataRepository.Setup(m => m.CreateEventParticipant(It.IsAny<EventParticipant>())).Returns(7890);
+
+      var result = _fixture.SignupUser(signupData);
+
+      Assert.True(result);
+    }
+  }
+}

--- a/CrdsGoLocalApi/Models/GOLocalKids.cs
+++ b/CrdsGoLocalApi/Models/GOLocalKids.cs
@@ -1,0 +1,21 @@
+﻿using Crossroads.Web.Common.MinistryPlatform;
+using Newtonsoft.Json;
+
+namespace CrdsGoLocalApi.Models
+{
+  [MpRestApiTable(Name = "cr_Go_Local_Kids")]
+  public class GoLocalKids
+  {
+    [JsonProperty(PropertyName = "Go_Local_Kids_ID")]
+    public int GoLocalKidsId { get; set; }
+
+    [JsonProperty(PropertyName = "Group_Participant_ID")]
+    public int GroupParticipantId { get; set; }
+
+    [JsonProperty(PropertyName = "Two_to_Seven_Count")]
+    public int TwoToSeven { get; set; }
+
+    [JsonProperty(PropertyName = "Eight_to_Twelve_Count")]
+    public int EightToTwelve { get; set; }
+  }
+}

--- a/CrdsGoLocalApi/Models/VolunteerDTO.cs
+++ b/CrdsGoLocalApi/Models/VolunteerDTO.cs
@@ -23,10 +23,10 @@ namespace CrdsGoLocalApi.Models
     [JsonProperty(PropertyName = "projectId")]
     public int ProjectId { get; set; }
 
-    [JsonProperty(PropertyName = "")]
+    [JsonProperty(PropertyName = "countOfKidsBetweenTwoAndSeven")]
     public int KidsTwoToSevenCount { get; set; }
 
-    [JsonProperty(PropertyName = "")]
+    [JsonProperty(PropertyName = "countOfKidsBetweenEightAndTwelve")]
     public int KidsEightToTwelveCount { get; set; }
   }
 }

--- a/CrdsGoLocalApi/Models/VolunteerDTO.cs
+++ b/CrdsGoLocalApi/Models/VolunteerDTO.cs
@@ -22,5 +22,11 @@ namespace CrdsGoLocalApi.Models
 
     [JsonProperty(PropertyName = "projectId")]
     public int ProjectId { get; set; }
+
+    [JsonProperty(PropertyName = "")]
+    public int KidsTwoToSevenCount { get; set; }
+
+    [JsonProperty(PropertyName = "")]
+    public int KidsEightToTwelveCount { get; set; }
   }
 }

--- a/CrdsGoLocalApi/Repositories/ParticipantData/IParticipantDataRepository.cs
+++ b/CrdsGoLocalApi/Repositories/ParticipantData/IParticipantDataRepository.cs
@@ -7,5 +7,6 @@ namespace CrdsGoLocalApi.Repositories.ParticipantData
     int CreateParticipant(Participant participantData);
     int CreateEventParticipant(EventParticipant eventParticipantData);
     int CreateGroupParticipant(GroupParticipant groupParticipantData);
+    int CreateGoLocalKids(GoLocalKids kidsData);
   }
 }

--- a/CrdsGoLocalApi/Repositories/ParticipantData/ParticipantDataRepository.cs
+++ b/CrdsGoLocalApi/Repositories/ParticipantData/ParticipantDataRepository.cs
@@ -44,5 +44,15 @@ namespace CrdsGoLocalApi.Repositories.ParticipantData
         .Create<GroupParticipant>(groupParticipantData);
       return groupParticipantData.GroupParticipantId;
     }
+
+    public int CreateGoLocalKids(GoLocalKids kidsData)
+    {
+      var apiToken = _tokenService.GetClientToken();
+      kidsData = _ministryPlatformBuilder.NewRequestBuilder()
+        .WithAuthenticationToken(apiToken)
+        .Build()
+        .Create<GoLocalKids>(kidsData);
+      return kidsData.GoLocalKidsId;
+    }
   }
 }

--- a/CrdsGoLocalApi/Services/Signup/SignupService.cs
+++ b/CrdsGoLocalApi/Services/Signup/SignupService.cs
@@ -41,6 +41,7 @@ namespace CrdsGoLocalApi.Services.Signup
         var participantId = CreateParticipant(contactId);
         var groupParticipantId = CreateGroupParticipant(participantId, project.GroupId);
         var eventParticipantId = CreateEventParticipant(participantId, groupParticipantId, project.EventId);
+        var goLocalKidsId = CreateGoLocalKids(groupParticipantId, signupData.KidsTwoToSevenCount,signupData.KidsEightToTwelveCount);
       }
       catch (Exception ex)
       {
@@ -127,6 +128,23 @@ namespace CrdsGoLocalApi.Services.Signup
       eventParticipant.EventParticipantId = _participantDataRepository.CreateEventParticipant(eventParticipant);
 
       return eventParticipant.EventParticipantId;
+    }
+
+    public int CreateGoLocalKids(int groupParticipantId, int kids2To7, int kids8To12)
+    {
+      if (groupParticipantId != 0 && kids2To7 + kids8To12 > 0)
+      {
+        var goLocalKids = new GoLocalKids
+        {
+          GroupParticipantId = groupParticipantId,
+          TwoToSeven = kids2To7,
+          EightToTwelve = kids8To12
+        };
+
+        goLocalKids.GoLocalKidsId = _participantDataRepository.CreateGoLocalKids(goLocalKids);
+        return goLocalKids.GoLocalKidsId;
+      }
+      return 0;
     }
   }
 }


### PR DESCRIPTION
## Purpose
Allow GO Local volutneers to bring kids aged 2-7 and 8-12

## Approach
Creates a GO Local kids record if they are bringing kids.

## Learning
Having a sub page in MP and giving the account access to that doesn't allow the API to create records. It must be a page. 
