### PR TITLE
Feature/us16505 send confirmation email

### DIFF
--- a/CI/SQL/20190320_093326_US16505-go-local-security-for-confirmation-email.sql
+++ b/CI/SQL/20190320_093326_US16505-go-local-security-for-confirmation-email.sql
@@ -1,8 +1,8 @@
 USE MinistryPlatform
 GO 
 
-DECLARE @GoLocalRoleId int = 211
-DECLARE @GroupPageId int = 322
+DECLARE @GoLocalRoleId int = 211;
+DECLARE @GroupPageId int = 322;
 
 IF NOT EXISTS (SELECT 1 FROM dp_Role_Pages WHERE Role_ID = @GoLocalRoleId AND Page_ID = @GroupPageId)
 BEGIN 

--- a/CI/SQL/20190320_093326_US16505-go-local-security-for-confirmation-email.sql
+++ b/CI/SQL/20190320_093326_US16505-go-local-security-for-confirmation-email.sql
@@ -1,0 +1,17 @@
+USE MinistryPlatform
+GO 
+
+DECLARE @GoLocalRoleId int = 211
+DECLARE @GroupPageId int = 322
+
+IF NOT EXISTS (SELECT 1 FROM dp_Role_Pages WHERE Role_ID = @GoLocalRoleId AND Page_ID = @GroupPageId)
+BEGIN 
+	INSERT INTO [dbo].[dp_Role_Pages]
+           ([Role_ID]
+           ,[Page_ID]
+           ,[Access_Level])
+     VALUES
+           (@GoLocalRoleId
+           ,@GroupPageId
+           ,1)
+END

--- a/CrdsGoLocalApi.Tests/Services/SignupServiceTests.cs
+++ b/CrdsGoLocalApi.Tests/Services/SignupServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using CrdsGoLocalApi.Models;
 using CrdsGoLocalApi.Repositories.ContactData;
+using CrdsGoLocalApi.Repositories.Email;
 using CrdsGoLocalApi.Repositories.HouseholdData;
 using CrdsGoLocalApi.Repositories.ParticipantData;
 using CrdsGoLocalApi.Repositories.ProjectData;
@@ -14,6 +15,7 @@ namespace CrdsGoLocalApi.Tests.Services
   public class SignupServiceTests : IDisposable
   {
     private readonly Mock<IContactDataRepository> _contactDataRepository;
+    private readonly Mock<IEmailRepository> _emailRepository;
     private readonly Mock<IHouseholdDataRepository> _householdDataRepository;
     private readonly Mock<IParticipantDataRepository> _participantDataRepository;
     private readonly Mock<IProjectDataRepository> _projectDataRepository;
@@ -23,15 +25,17 @@ namespace CrdsGoLocalApi.Tests.Services
     public SignupServiceTests()
     {
       _contactDataRepository = new Mock<IContactDataRepository>();
+      _emailRepository = new Mock<IEmailRepository>();
       _householdDataRepository = new Mock<IHouseholdDataRepository>();
       _participantDataRepository = new Mock<IParticipantDataRepository>();
       _projectDataRepository = new Mock<IProjectDataRepository>();
-      _fixture = new SignupService(_contactDataRepository.Object, _householdDataRepository.Object, _participantDataRepository.Object, _projectDataRepository.Object);
+      _fixture = new SignupService(_contactDataRepository.Object, _emailRepository.Object, _householdDataRepository.Object, _participantDataRepository.Object, _projectDataRepository.Object);
     }
 
     public void Dispose()
     {
       _contactDataRepository.VerifyAll();
+      _emailRepository.VerifyAll();
       _householdDataRepository.VerifyAll();
       _participantDataRepository.VerifyAll();
       _projectDataRepository.VerifyAll();
@@ -49,6 +53,7 @@ namespace CrdsGoLocalApi.Tests.Services
       _participantDataRepository.Setup(m => m.CreateGroupParticipant(It.IsAny<GroupParticipant>())).Returns(3456);
       _participantDataRepository.Setup(m => m.CreateEventParticipant(It.IsAny<EventParticipant>())).Returns(7890);
       _participantDataRepository.Setup(m => m.CreateGoLocalKids(It.IsAny<GoLocalKids>())).Returns(1357);
+      _emailRepository.Setup(m => m.SendConfirmationEmail(It.IsAny<MpProject>(), It.IsAny<VolunteerDTO>(), 1234)).Returns(true);
 
       var result = _fixture.SignupUser(signupData);
 
@@ -66,6 +71,7 @@ namespace CrdsGoLocalApi.Tests.Services
       _participantDataRepository.Setup(m => m.CreateParticipant(It.IsAny<Participant>())).Returns(9012);
       _participantDataRepository.Setup(m => m.CreateGroupParticipant(It.IsAny<GroupParticipant>())).Returns(3456);
       _participantDataRepository.Setup(m => m.CreateEventParticipant(It.IsAny<EventParticipant>())).Returns(7890);
+      _emailRepository.Setup(m => m.SendConfirmationEmail(It.IsAny<MpProject>(), It.IsAny<VolunteerDTO>(), 1234)).Returns(true);
 
       var result = _fixture.SignupUser(signupData);
 

--- a/CrdsGoLocalApi/Constants/MpConstants.cs
+++ b/CrdsGoLocalApi/Constants/MpConstants.cs
@@ -7,5 +7,6 @@
     public static readonly int RegisteredEventParticipantStatus = 2;
     public static readonly int ActiveContactStatus = 1;
     public static readonly int HeadOfHousehold = 1;
+    public static readonly int ConfirmationEmailTemplate = 169909;
   }
 }

--- a/CrdsGoLocalApi/Models/Group.cs
+++ b/CrdsGoLocalApi/Models/Group.cs
@@ -10,6 +10,6 @@ namespace CrdsGoLocalApi.Models
     public int GroupId { get; set; }
 
     [JsonProperty(PropertyName = "Primary_Contact")]
-    public int PrimaryContact { get; set; }
+    public int PrimaryContactId { get; set; }
   }
 }

--- a/CrdsGoLocalApi/Models/Group.cs
+++ b/CrdsGoLocalApi/Models/Group.cs
@@ -1,0 +1,15 @@
+﻿using Crossroads.Web.Common.MinistryPlatform;
+using Newtonsoft.Json;
+
+namespace CrdsGoLocalApi.Models
+{
+  [MpRestApiTable(Name = "Groups")]
+  public class Group
+  {
+    [JsonProperty(PropertyName = "Group_ID")]
+    public int GroupId { get; set; }
+
+    [JsonProperty(PropertyName = "Primary_Contact")]
+    public int PrimaryContact { get; set; }
+  }
+}

--- a/CrdsGoLocalApi/Models/NewVolunteer.cs
+++ b/CrdsGoLocalApi/Models/NewVolunteer.cs
@@ -1,0 +1,8 @@
+﻿namespace CrdsGoLocalApi.Models
+{
+  public class NewVolunteer
+  {
+    public int ContactId { get; set; }
+    public int GroupParticipantId { get; set; }
+  }
+}

--- a/CrdsGoLocalApi/Repositories/Email/EmailRepository.cs
+++ b/CrdsGoLocalApi/Repositories/Email/EmailRepository.cs
@@ -24,8 +24,8 @@ namespace CrdsGoLocalApi.Repositories.Email
       var email = new EmailCommunication
       {
         ToContactId = new List<int>{ toContact },
-        FromContactId = group.PrimaryContact,
-        SenderContactId = group.PrimaryContact,
+        FromContactId = group.PrimaryContactId,
+        SenderContactId = group.PrimaryContactId,
         TemplateId = MpConstants.ConfirmationEmailTemplate,
         MergeData = new Dictionary<string, object>
         {

--- a/CrdsGoLocalApi/Repositories/Email/EmailRepository.cs
+++ b/CrdsGoLocalApi/Repositories/Email/EmailRepository.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using CrdsGoLocalApi.Constants;
 using CrdsGoLocalApi.Models;
 using CrdsGoLocalApi.Repositories.GroupData;
 using Crossroads.Web.Common.MinistryPlatform;
 using Crossroads.Web.Common.Models;
 
-namespace CrdsGoLocalApi.Services.Email
+namespace CrdsGoLocalApi.Repositories.Email
 {
   public class EmailRepository : IEmailRepository
   {
@@ -28,13 +29,13 @@ namespace CrdsGoLocalApi.Services.Email
         TemplateId = MpConstants.ConfirmationEmailTemplate,
         MergeData = new Dictionary<string, object>
         {
-          {"[Project_Name]", projectData.ProjectName },
-          {"[Address]", $"{projectData.Address1} {projectData.Address2} {projectData.AddressCity}, {projectData.AddressState} {projectData.AddressZip}" },
-          {"[Start_Date]", projectData.StartDate },
-          {"[Project_Type_Description]", projectData.ProjectType },
-          {"[Kids_2_7]", volunteerData.KidsTwoToSevenCount },
-          {"[Kids_8_12]", volunteerData.KidsEightToTwelveCount },
-          //{"[Guest_List]", volunteerData.Guests }
+          {"Project_Name", projectData.ProjectName },
+          {"Address", $"{projectData.Address1} {projectData.Address2} {projectData.AddressCity}, {projectData.AddressState} {projectData.AddressZip}" },
+          {"Start_Date", projectData.StartDate },
+          {"Project_Type_Description", projectData.ProjectType },
+          {"Kids_2_7", volunteerData.KidsTwoToSevenCount },
+          {"Kids_8_12", volunteerData.KidsEightToTwelveCount },
+          {"Guest_List", "<div style=\"margin-left: 40px\">" + string.Join("<br>", volunteerData.Guests.Select(g => g.FirstName + " " + g.LastName)) + "</div>" }
         }
       };
       var sent = _emailSender.SendEmail(email, false).Result;

--- a/CrdsGoLocalApi/Repositories/Email/EmailRepository.cs
+++ b/CrdsGoLocalApi/Repositories/Email/EmailRepository.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using CrdsGoLocalApi.Constants;
+using CrdsGoLocalApi.Models;
+using CrdsGoLocalApi.Repositories.GroupData;
+using Crossroads.Web.Common.MinistryPlatform;
+using Crossroads.Web.Common.Models;
+
+namespace CrdsGoLocalApi.Services.Email
+{
+  public class EmailRepository : IEmailRepository
+  {
+    private readonly IGroupDataRepository _groupRepository;
+    private readonly IMpEmailSender _emailSender;
+
+    public EmailRepository(IGroupDataRepository groupData, IMpEmailSender emailSender)
+    {
+      _emailSender = emailSender;
+      _groupRepository = groupData;
+    }
+    public bool SendConfirmationEmail(MpProject projectData, VolunteerDTO volunteerData, int toContact)
+    {
+      var group = _groupRepository.GetGroup(projectData.GroupId.Value);
+      var email = new EmailCommunication
+      {
+        ToContactId = new List<int>{ toContact },
+        FromContactId = group.PrimaryContact,
+        SenderContactId = group.PrimaryContact,
+        TemplateId = MpConstants.ConfirmationEmailTemplate,
+        MergeData = new Dictionary<string, object>
+        {
+          {"[Project_Name]", projectData.ProjectName },
+          {"[Address]", $"{projectData.Address1} {projectData.Address2} {projectData.AddressCity}, {projectData.AddressState} {projectData.AddressZip}" },
+          {"[Start_Date]", projectData.StartDate },
+          {"[Project_Type_Description]", projectData.ProjectType },
+          {"[Kids_2_7]", volunteerData.KidsTwoToSevenCount },
+          {"[Kids_8_12]", volunteerData.KidsEightToTwelveCount },
+          //{"[Guest_List]", volunteerData.Guests }
+        }
+      };
+      var sent = _emailSender.SendEmail(email, false).Result;
+      return sent;
+    }
+  }
+}

--- a/CrdsGoLocalApi/Repositories/Email/EmailRepository.cs
+++ b/CrdsGoLocalApi/Repositories/Email/EmailRepository.cs
@@ -18,12 +18,12 @@ namespace CrdsGoLocalApi.Repositories.Email
       _emailSender = emailSender;
       _groupRepository = groupData;
     }
-    public bool SendConfirmationEmail(MpProject projectData, VolunteerDTO volunteerData, int toContact)
+    public bool SendConfirmationEmail(MpProject projectData, VolunteerDTO volunteerData, int toContactId)
     {
       var group = _groupRepository.GetGroup(projectData.GroupId.Value);
       var email = new EmailCommunication
       {
-        ToContactId = new List<int>{ toContact },
+        ToContactId = new List<int>{ toContactId },
         FromContactId = group.PrimaryContactId,
         SenderContactId = group.PrimaryContactId,
         TemplateId = MpConstants.ConfirmationEmailTemplate,

--- a/CrdsGoLocalApi/Repositories/Email/IEmailRepository.cs
+++ b/CrdsGoLocalApi/Repositories/Email/IEmailRepository.cs
@@ -1,0 +1,9 @@
+using CrdsGoLocalApi.Models;
+
+namespace CrdsGoLocalApi.Services.Email
+{
+  public interface IEmailRepository
+  {
+    bool SendConfirmationEmail(MpProject projectData, int toContact);
+  }
+}

--- a/CrdsGoLocalApi/Repositories/Email/IEmailRepository.cs
+++ b/CrdsGoLocalApi/Repositories/Email/IEmailRepository.cs
@@ -4,6 +4,6 @@ namespace CrdsGoLocalApi.Repositories.Email
 {
   public interface IEmailRepository
   {
-    bool SendConfirmationEmail(MpProject projectData, VolunteerDTO volunteerData, int toContact);
+    bool SendConfirmationEmail(MpProject projectData, VolunteerDTO volunteerData, int toContactId);
   }
 }

--- a/CrdsGoLocalApi/Repositories/Email/IEmailRepository.cs
+++ b/CrdsGoLocalApi/Repositories/Email/IEmailRepository.cs
@@ -1,9 +1,9 @@
 using CrdsGoLocalApi.Models;
 
-namespace CrdsGoLocalApi.Services.Email
+namespace CrdsGoLocalApi.Repositories.Email
 {
   public interface IEmailRepository
   {
-    bool SendConfirmationEmail(MpProject projectData, int toContact);
+    bool SendConfirmationEmail(MpProject projectData, VolunteerDTO volunteerData, int toContact);
   }
 }

--- a/CrdsGoLocalApi/Repositories/GroupData/GroupDataRepository.cs
+++ b/CrdsGoLocalApi/Repositories/GroupData/GroupDataRepository.cs
@@ -1,0 +1,28 @@
+﻿using CrdsGoLocalApi.Models;
+using CrdsGoLocalApi.Services.Token;
+using Crossroads.Web.Common.MinistryPlatform;
+
+namespace CrdsGoLocalApi.Repositories.GroupData
+{
+  public class GroupDataRepository : IGroupDataRepository
+  {
+    private readonly ITokenService _tokenService;
+    private readonly IMinistryPlatformRestRequestBuilderFactory _ministryPlatformBuilder;
+
+    public GroupDataRepository(ITokenService tokenService, IMinistryPlatformRestRequestBuilderFactory ministryPlatformRestRequestBuilderFactory)
+    {
+      _tokenService = tokenService;
+      _ministryPlatformBuilder = ministryPlatformRestRequestBuilderFactory;
+    }
+
+    public Group GetGroup(int groupId)
+    {
+      var apiToken = _tokenService.GetClientToken();
+      var group = _ministryPlatformBuilder.NewRequestBuilder()
+        .WithAuthenticationToken(apiToken)
+        .Build()
+        .Get<Group>(groupId);
+      return group;
+    }
+  }
+}

--- a/CrdsGoLocalApi/Repositories/GroupData/IGroupDataRepository.cs
+++ b/CrdsGoLocalApi/Repositories/GroupData/IGroupDataRepository.cs
@@ -1,0 +1,9 @@
+﻿using CrdsGoLocalApi.Models;
+
+namespace CrdsGoLocalApi.Repositories.GroupData
+{
+  public interface IGroupDataRepository
+  {
+    Group GetGroup(int groupId);
+  }
+}

--- a/CrdsGoLocalApi/Services/Signup/SignupService.cs
+++ b/CrdsGoLocalApi/Services/Signup/SignupService.cs
@@ -5,6 +5,7 @@ using CrdsGoLocalApi.Repositories.ContactData;
 using CrdsGoLocalApi.Repositories.HouseholdData;
 using CrdsGoLocalApi.Repositories.ParticipantData;
 using CrdsGoLocalApi.Repositories.ProjectData;
+using CrdsGoLocalApi.Services.Email;
 using Newtonsoft.Json;
 
 namespace CrdsGoLocalApi.Services.Signup
@@ -12,15 +13,17 @@ namespace CrdsGoLocalApi.Services.Signup
   public class SignupService : ISignupService
   {
     private readonly IContactDataRepository _contactDataRepository;
+    private readonly IEmailRepository _emailRepository;
     private readonly IHouseholdDataRepository _householdDataRepository;
     private readonly IParticipantDataRepository _participantDataRepository;
     private readonly IProjectDataRepository _projectDataRepository;
 
     private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 
-    public SignupService(IContactDataRepository contactData, IHouseholdDataRepository householdData, IParticipantDataRepository participantData, IProjectDataRepository projectData)
+    public SignupService(IContactDataRepository contactData, IEmailRepository emailRepository, IHouseholdDataRepository householdData, IParticipantDataRepository participantData, IProjectDataRepository projectData)
     {
       _contactDataRepository = contactData;
+      _emailRepository = emailRepository;
       _householdDataRepository = householdData;
       _participantDataRepository = participantData;
       _projectDataRepository = projectData;
@@ -42,6 +45,8 @@ namespace CrdsGoLocalApi.Services.Signup
         var groupParticipantId = CreateGroupParticipant(participantId, project.GroupId);
         var eventParticipantId = CreateEventParticipant(participantId, groupParticipantId, project.EventId);
         var goLocalKidsId = CreateGoLocalKids(groupParticipantId, signupData.KidsTwoToSevenCount,signupData.KidsEightToTwelveCount);
+
+        succeeded = _emailRepository.SendConfirmationEmail(project, contactId);
       }
       catch (Exception ex)
       {

--- a/CrdsGoLocalApi/Startup.cs
+++ b/CrdsGoLocalApi/Startup.cs
@@ -1,4 +1,6 @@
 ﻿using CrdsGoLocalApi.Repositories.ContactData;
+using CrdsGoLocalApi.Repositories.Email;
+using CrdsGoLocalApi.Repositories.GroupData;
 using CrdsGoLocalApi.Repositories.HouseholdData;
 using CrdsGoLocalApi.Repositories.ParticipantData;
 using CrdsGoLocalApi.Repositories.ProjectData;
@@ -42,6 +44,8 @@ namespace CrdsGoLocalApi
       CrossroadsWebCommonConfig.Register(services);
       services.AddSingleton<ICacheService, CacheService>();
       services.AddSingleton<IContactDataRepository, ContactDataRepository>();
+      services.AddSingleton<IEmailRepository, EmailRepository>();
+      services.AddSingleton<IGroupDataRepository, GroupDataRepository>();
       services.AddSingleton<IHouseholdDataRepository, HouseholdDataRepository>();
       services.AddSingleton<IParticipantDataRepository, ParticipantDataRepository>();
       services.AddSingleton<IProjectDataRepository, ProjectDataRepository>();


### PR DESCRIPTION
## Purpose
Send an email to a volunteer to confirm that we have recorded their registration

## Approach
Uses the Email Sender from web.common.

#### Open  TODOs
The confirmation email template needs to be styled and copied to all environments before the story should be tested. 
