### PR TITLE
DE6639 initialize FamilyMembers property so we don't get error

### DIFF
--- a/CrdsGoLocalApi/Services/Signup/SignupService.cs
+++ b/CrdsGoLocalApi/Services/Signup/SignupService.cs
@@ -102,6 +102,7 @@ namespace CrdsGoLocalApi.Services.Signup
           newVol.HouseholdId,
           householdPostionId);
         newVol.ParticipantId = CreateParticipant(newVol.ContactId);
+        newVol.FamilyMembers = new List<HouseholdMembers>();
       }
       else
       {


### PR DESCRIPTION
## Purpose
Fix error when a non-logged-in user signs up family members

## Approach
The FamilyMembers property wasn't getting initialized for a new contact, which was causing an exception when we tried to access it later. I made sure all flows will put something in that property. 
