### PR TITLE
Handle if a family member doesn't have a birthdate.

### DIFF
--- a/CrdsGoLocalApi/Models/HouseholdMembers.cs
+++ b/CrdsGoLocalApi/Models/HouseholdMembers.cs
@@ -17,7 +17,7 @@ namespace CrdsGoLocalApi.Models
     public string LastName { get; set; }
 
     [JsonProperty(PropertyName = "Date_of_Birth")]
-    public DateTime DateOfBirth { get; set; }
+    public DateTime? DateOfBirth { get; set; }
 
     [JsonProperty(PropertyName = "Household_Position_ID")]
     public int HouseholdPosition { get; set; }

--- a/CrdsGoLocalApi/Services/Signup/SignupService.cs
+++ b/CrdsGoLocalApi/Services/Signup/SignupService.cs
@@ -277,7 +277,7 @@ namespace CrdsGoLocalApi.Services.Signup
       return household.FirstOrDefault(h =>
         h.FirstName == guest.FirstName &&
         h.LastName == guest.LastName &&
-        h.DateOfBirth.Date == guest.BirthDate.Date)?.ContactId;
+        h.DateOfBirth?.Date == guest.BirthDate.Date)?.ContactId;
     }
   }
 }


### PR DESCRIPTION
## Purpose
When a logged in user had household members who didn't have a birthdate, we got an error. 

## Approach
Made household member birthdate nullable.
